### PR TITLE
Parameter matching problem fix

### DIFF
--- a/R/framework.R
+++ b/R/framework.R
@@ -160,17 +160,7 @@ UseFunction <- function(fn,fn.name, ...)
     stop(use_error(.ERR_USE_FUNCTION,fn.name,raw.args))
   
   # use eval(parse(text = str)), instead of do.call
-  raw.args.list <- list()
-  invisible(lapply(raw.args, function(i) {
-    name <- names(raw.args[i])
-    value <- as.character(raw.args[i])
-    if(is.null(name) || name == '') {
-      raw.args.list <<- append(raw.args.list, value)
-    } else raw.args.list <<- append(raw.args.list, paste(name, value, sep = ' = '))
-  }))
-  raw.args.list <- append(raw.args.list, ', ')
-  names(raw.args.list)[length(raw.args.list)] <- 'sep'
-  raw.args.string <- do.call(paste, raw.args.list)
+  raw.args.string <- get_args_raw_string(raw.args)
   result <- eval(parse(text = paste('matched.fn(', raw.args.string, ')')))
   #result <- do.call(matched.fn, full.args)
 
@@ -196,10 +186,22 @@ UseFunction <- function(fn,fn.name, ...)
       stop(use_error(msg,fn.name,raw.args))
     }
   }
-
   result
 }
 
+get_args_raw_string <- function(raw.args) {
+  raw.args.list <- list()
+  invisible(lapply(1:length(raw.args), function(i) {
+    name <- names(raw.args[i])
+    value <- as.character(raw.args[i])
+    if(is.null(name) || name == '') {
+      raw.args.list <<- append(raw.args.list, value)
+    } else raw.args.list <<- append(raw.args.list, paste(name, value, sep = ' = '))
+  }))
+  raw.args.list <- append(raw.args.list, ', ')
+  names(raw.args.list)[length(raw.args.list)] <- 'sep'
+  do.call(paste, raw.args.list)
+}
 
 idx_ellipsis <- function(tree) {
   which(tree$args$token == '...')

--- a/R/framework.R
+++ b/R/framework.R
@@ -158,8 +158,21 @@ UseFunction <- function(fn,fn.name, ...)
   }
   if (is.null(matched.fn))
     stop(use_error(.ERR_USE_FUNCTION,fn.name,raw.args))
-
-  result <- do.call(matched.fn, full.args)
+  
+  # use eval(parse(text = str)), instead of do.call
+  raw.args.list <- list()
+  invisible(lapply(raw.args, function(i) {
+    name <- names(raw.args[i])
+    value <- as.character(raw.args[i])
+    if(is.null(name) || name == '') {
+      raw.args.list <<- append(raw.args.list, value)
+    } else raw.args.list <<- append(raw.args.list, paste(name, value, sep = ' = '))
+  }))
+  raw.args.list <- append(raw.args.list, ', ')
+  names(raw.args.list)[length(raw.args.list)] <- 'sep'
+  raw.args.string <- do.call(paste, raw.args.list)
+  result <- eval(parse(text = paste('matched.fn(', raw.args.string, ')')))
+  #result <- do.call(matched.fn, full.args)
 
   if (!is.null(full.type))
   {
@@ -233,7 +246,7 @@ fill_args <- function(params, tokens, defaults, idx.ellipsis)
   named.params <- param.names[param.names %in% tokens]
   args[named.params] <- params[named.params]
 
-# TODO refer: https://cran.r-project.org/doc/manuals/R-lang.html#Argument-matching
+# TODO: refer: https://cran.r-project.org/doc/manuals/R-lang.html#Argument-matching
 # after matching tags,
 # do positional matching procedure. 
 # bound all unmatched arguments to supplied arguments

--- a/R/framework.R
+++ b/R/framework.R
@@ -233,6 +233,12 @@ fill_args <- function(params, tokens, defaults, idx.ellipsis)
   named.params <- param.names[param.names %in% tokens]
   args[named.params] <- params[named.params]
 
+# TODO refer: https://cran.r-project.org/doc/manuals/R-lang.html#Argument-matching
+# after matching tags,
+# do positional matching procedure. 
+# bound all unmatched arguments to supplied arguments
+
+
   # Catalog named and unnamed arguments
   if (length(params) > 0) {
     idx.params <- 1:length(params)
@@ -248,7 +254,7 @@ fill_args <- function(params, tokens, defaults, idx.ellipsis)
       idx.a.named <- idx.concrete[named.params]
       idx.a.unnamed <- idx.concrete[-idx.a.named]
     }
-
+    
     if (length(idx.ellipsis) > 0) {
       # Choose only required arguments
       idx.required <- idx.concrete[is.na(defaults)]
@@ -769,7 +775,8 @@ add_variant <- function(fn.name, tree, where)
     tree$accepts <- c(0,0)
   else {
     args <- tree$args
-    required.args <- length(args$default[is.na(args$default)])
+#    required.args <- length(args$default[is.na(args$default)])
+    required.args <- sum(is.na(args$default))
     if ('...' %in% tree$args$token)
       tree$accepts <- c(required.args-1, Inf)
       #tree$accepts <- c(required.args : nrow(args) - 1, Inf)

--- a/R/framework.R
+++ b/R/framework.R
@@ -160,9 +160,9 @@ UseFunction <- function(fn,fn.name, ...)
     stop(use_error(.ERR_USE_FUNCTION,fn.name,raw.args))
   
   # use eval(parse(text = str)), instead of do.call
-  raw.args.string <- get_args_raw_string(raw.args)
-  result <- eval(parse(text = paste('matched.fn(', raw.args.string, ')')))
-  #result <- do.call(matched.fn, full.args)
+  #raw.args.string <- get_args_raw_string(raw.args)
+  #result <- eval(parse(text = paste('matched.fn(', raw.args.string, ')')))
+  result <- do.call(matched.fn, full.args)
 
   if (!is.null(full.type))
   {
@@ -193,7 +193,7 @@ get_args_raw_string <- function(raw.args) {
   raw.args.list <- list()
   invisible(lapply(1:length(raw.args), function(i) {
     name <- names(raw.args[i])
-    value <- as.character(raw.args[i])
+    value <- paste0("raw.args[[", i, "]]")
     if(is.null(name) || name == '') {
       raw.args.list <<- append(raw.args.list, value)
     } else raw.args.list <<- append(raw.args.list, paste(name, value, sep = ' = '))

--- a/R/framework.R
+++ b/R/framework.R
@@ -246,12 +246,6 @@ fill_args <- function(params, tokens, defaults, idx.ellipsis)
   named.params <- param.names[param.names %in% tokens]
   args[named.params] <- params[named.params]
 
-# TODO: refer: https://cran.r-project.org/doc/manuals/R-lang.html#Argument-matching
-# after matching tags,
-# do positional matching procedure. 
-# bound all unmatched arguments to supplied arguments
-
-
   # Catalog named and unnamed arguments
   if (length(params) > 0) {
     idx.params <- 1:length(params)
@@ -267,7 +261,7 @@ fill_args <- function(params, tokens, defaults, idx.ellipsis)
       idx.a.named <- idx.concrete[named.params]
       idx.a.unnamed <- idx.concrete[-idx.a.named]
     }
-    
+
     if (length(idx.ellipsis) > 0) {
       # Choose only required arguments
       idx.required <- idx.concrete[is.na(defaults)]
@@ -788,7 +782,6 @@ add_variant <- function(fn.name, tree, where)
     tree$accepts <- c(0,0)
   else {
     args <- tree$args
-#    required.args <- length(args$default[is.na(args$default)])
     required.args <- sum(is.na(args$default))
     if ('...' %in% tree$args$token)
       tree$accepts <- c(required.args-1, Inf)


### PR DESCRIPTION
This PR calls the function directly from input, not from the manual parameter matching. 
With the following test case, there might still be issues with parameter matching when matching which function to call. 

But calling the function now won't cause any problem. 

Here is the test case: 
library(lambda.r)
```
f1 (a = 1, ...) %as% {
    vs <- list(...)
    print(vs)
    NULL
}
f1(1, 2, 3)

```

before the change: 
```

> library(lambda.r)
> f1 (a = 1, ...) %as% {
+     vs <- list(...)
+     print(vs)
+     NULL
+ }
> f1(1, 2, 3)
[[1]]
[1] 1

[[2]]
[1] 2

[[3]]
[1] 3

NULL

```

After the change:

```
> library(lambda.r)
> f1 (a = 1, ...) %as% {
+     vs <- list(...)
+     print(vs)
+     NULL
+ }
> f1(1, 2, 3)
[[1]]
[1] 2

[[2]]
[1] 3

NULL
```